### PR TITLE
Implement yaml metadata hook

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for pmarkdown and the Markdown::Perl module.
 
+1.08 - ?
+
+ - Add a new yaml_metadata hook to receive the parsed YAML.
+
 1.07 - 2024-05-25
 
  - Allow to specify a link content through the resolve_link_ref hook.

--- a/lib/Markdown/Perl.pm
+++ b/lib/Markdown/Perl.pm
@@ -50,7 +50,7 @@ sub set_mode {
   return;
 }
 
-Readonly::Array my @VALID_HOOKS => qw(resolve_link_ref);
+Readonly::Array my @VALID_HOOKS => qw(resolve_link_ref yaml_metadata);
 
 sub set_hooks {
   my ($this, %hooks) = &_get_this_and_args;  ## no critic (ProhibitAmpersandSigils)
@@ -323,6 +323,8 @@ hash-reference containing a C<target> key, pointing to the link destination and
 optionally a C<title> key containing the title of the key. The hash-ref can also
 contain a C<content> key, in which case its value should be a span of HTML which
 will replace whatever would have been used for the link content.
+
+C<yaml_metadata>: this hook will trigger if there is valid (!) YAML metadata in the file and will give you a YAML::Tiny object as an argument.
 
 =back
 

--- a/lib/Markdown/Perl.pm
+++ b/lib/Markdown/Perl.pm
@@ -324,7 +324,12 @@ optionally a C<title> key containing the title of the key. The hash-ref can also
 contain a C<content> key, in which case its value should be a span of HTML which
 will replace whatever would have been used for the link content.
 
-C<yaml_metadata>: this hook will trigger if there is valid (!) YAML metadata in the file and will give you a YAML::Tiny object as an argument. If the hook returns a falsy value, the Markdown parsing will stop. This allows for conditional parsing based on values in the metadata section.
+=item *
+
+C<yaml_metadata>: this hook will trigger if there is valid (!) YAML metadata in 
+the file and will give you a YAML::Tiny object as an argument. If the hook throws 
+a die(), the Markdown parsing will stop. This allows for conditional parsing 
+based on values in the metadata section.
 
 =back
 

--- a/lib/Markdown/Perl.pm
+++ b/lib/Markdown/Perl.pm
@@ -327,9 +327,9 @@ will replace whatever would have been used for the link content.
 =item *
 
 C<yaml_metadata>: this hook will trigger if there is valid (!) YAML metadata in 
-the file and will give you a YAML::Tiny object as an argument. If the hook throws 
-a die(), the Markdown parsing will stop. This allows for conditional parsing 
-based on values in the metadata section.
+the file and will give you a hashref as an argument. If the hook throws a die(),
+the Markdown parsing will stop as the die() needs to be handled by your code. 
+This allows for conditional parsing based on values in the metadata section.
 
 =back
 

--- a/lib/Markdown/Perl.pm
+++ b/lib/Markdown/Perl.pm
@@ -324,7 +324,7 @@ optionally a C<title> key containing the title of the key. The hash-ref can also
 contain a C<content> key, in which case its value should be a span of HTML which
 will replace whatever would have been used for the link content.
 
-C<yaml_metadata>: this hook will trigger if there is valid (!) YAML metadata in the file and will give you a YAML::Tiny object as an argument.
+C<yaml_metadata>: this hook will trigger if there is valid (!) YAML metadata in the file and will give you a YAML::Tiny object as an argument. If the hook returns a falsy value, the Markdown parsing will stop. This allows for conditional parsing based on values in the metadata section.
 
 =back
 

--- a/lib/Markdown/Perl/BlockParser.pm
+++ b/lib/Markdown/Perl/BlockParser.pm
@@ -137,15 +137,7 @@ sub process {
   # Done at a later stage, as escaped characters don’t have their Markdown
   # meaning, we need a way to represent that.
 
-  if($this->get_parse_file_metadata eq 'yaml') {
-    my $hook_result = eval {
-      $this->_parse_yaml_metadata();
-    };
-    if(!defined($hook_result)) { # eval returns undef on die(), syntax error, ..
-      carp "yaml_metadata hook died. Not parsing the Markdown.\n";
-      return;
-    }
-  }
+  $this->_parse_yaml_metadata() if $this->get_parse_file_metadata eq 'yaml';
 
   while (defined (my $l = $this->next_line())) {
     # This field might be set to true at the beginning of the processing, while
@@ -382,8 +374,8 @@ sub _parse_yaml_metadata {
       carp 'YAML Metadata (Markdown frontmatter) is invalid.';
       return 1;
     }
-    if(exists($this->{pmarkdown}->{hooks}->{yaml_metadata})) {
-      $this->{pmarkdown}->{hooks}->{yaml_metadata}->($metadata);
+    if(exists($this->{pmarkdown}{hooks}{yaml_metadata})) {
+      $this->{pmarkdown}{hooks}{yaml_metadata}->($metadata->[0]);
     }
   }
   return 1;

--- a/lib/Markdown/Perl/BlockParser.pm
+++ b/lib/Markdown/Perl/BlockParser.pm
@@ -374,6 +374,9 @@ sub _parse_yaml_metadata {
       pos($this->{md}) = 0;
       return;
     }
+    if(exists($this->{pmarkdown}) && exists($this->{pmarkdown}->{hooks}->{yaml_metadata})) {
+      my $hook_result = $this->{pmarkdown}->{hooks}->{yaml_metadata}->($metadata);
+    }
   }
 
   return;

--- a/lib/Markdown/Perl/BlockParser.pm
+++ b/lib/Markdown/Perl/BlockParser.pm
@@ -139,7 +139,7 @@ sub process {
 
   if($this->get_parse_file_metadata eq 'yaml') {
     my $hook_result = eval {
-	  $this->_parse_yaml_metadata();
+      $this->_parse_yaml_metadata();
     };
     if(!defined($hook_result)) { # eval returns undef on die(), syntax error, ..
       carp "yaml_metadata hook died. Not parsing the Markdown.\n";

--- a/lib/Markdown/Perl/Options.pm
+++ b/lib/Markdown/Perl/Options.pm
@@ -181,9 +181,8 @@ sub _word_list {
 =head3 B<parse_file_metadata> I<(enum, default: yaml)>
 
 This option controls whether the parser accepts optional metadata at the
-beginning of the file. Currently, it does nothing with these metadata, even when
-they are accepted. In the future they might be used to build complete HTML file
-instead of just fragment.
+beginning of the file. The module does nothing with the metadata itself but you
+can configure a hook to intercept the YAML.
 
 The possible values are:
 

--- a/t/501-hooks-yaml-metadata.t
+++ b/t/501-hooks-yaml-metadata.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use utf8;
+
+use Markdown::Perl 'convert', 'set_hooks';
+use Test2::V0;
+
+my $p = Markdown::Perl->new();
+my $page = <<EOF;
+---
+name: Mark is down
+draft: false
+number: 42
+---
+# Mark is down!
+
+I repeat: "Mark is down!"
+EOF
+
+# Test 1: Check if we can get a string value
+{
+  sub hook_is_name_mark {
+    my $x = shift;
+    ok(exists($x->[0]->{name}) && $x->[0]->{name} eq 'Mark is down', "key 'name' was retrieved and validated as being 'Mark is down'");
+  }
+  $p->set_hooks(yaml_metadata => \&hook_is_name_mark);
+  $p->convert($page);
+}
+
+# Test 2: Validate that hook is not called if yaml is invalid
+
+done_testing;

--- a/t/501-hooks-yaml-metadata.t
+++ b/t/501-hooks-yaml-metadata.t
@@ -17,6 +17,17 @@ number: 42
 I repeat: "Mark is down!"
 EOF
 
+my $invalid_page = <<EOF;
+---
+name: Mark is down
+  draft: false
+	number: 42
+---
+# Mark is down!
+
+I repeat: "Mark is down!"
+EOF
+
 # Test 1: Check if we can get a string value
 {
   sub hook_is_name_mark {
@@ -28,5 +39,14 @@ EOF
 }
 
 # Test 2: Validate that hook is not called if yaml is invalid
+{
+  my $hook_called = 0;
+  sub hook_called {
+    $hook_called = 1;
+  }
+  $p->set_hooks(yaml_metadata => \&hook_called);
+  ok(!$hook_called, "Hook was not called because metadata was invalid.");
+  $p->convert($invalid_page);
+}
 
 done_testing;

--- a/t/501-hooks-yaml-metadata.t
+++ b/t/501-hooks-yaml-metadata.t
@@ -5,6 +5,7 @@ use utf8;
 use Markdown::Perl 'convert', 'set_hooks';
 use Test::More;
 use Test2::Tools::Warnings;
+use Test2::Tools::Exception;
 
 my $p = Markdown::Perl->new();
 my $page = <<EOF;
@@ -64,9 +65,7 @@ EOF
     die "last words";
   }
   $p->set_hooks(yaml_metadata => \&hook_die);
-  my $eval_result = eval { $p->convert($page) };
-  ok(!defined($eval_result) && $@, "The code died correctly");
-  ok($@ =~ /^last words/, "Code died with the correct message");
+  like( dies { $p->convert($page) }, qr/last words/, "The hook correctly died.");
 }
 
 done_testing;


### PR DESCRIPTION
I'm using your module in a personal project where I need to parse Markdown files and would find it useful if I can (ab)use your Perl module to do the metadata parsing. As for now I need to make my own little subroutine to read the markdown file, extract the yaml and pass it to a yaml parser, to then pass it to the Markdown::Perl converter.

Since you already make a hooks implementation, I added the functionality as a hook that can be called.

TODO (this is a note for myself): 
* [ ] Update docs and notes where it says that the metadata is unused
* [ ] Allow the return value of the hook to decide whether parsingof the Markdown document should continue or not (handy if you want to filter through a huge list of markdown files but only want to parse files with a certain YAML key set)
* [ ] Gather feedback